### PR TITLE
feat: add qwen3 coder plus vscode command

### DIFF
--- a/packages/vscode-ide-companion/README.md
+++ b/packages/vscode-ide-companion/README.md
@@ -8,6 +8,10 @@ The Qwen Code Companion extension seamlessly integrates [Qwen Code](https://gith
 
 - Selection Context: Qwen Code can easily access your cursor's position and selected text within the editor, giving it valuable context directly from your current work.
 
+# Usage
+
+Set the `QWEN_API_KEY` environment variable before launching VS Code. Run **Qwen Code: Run** from the command palette to send a prompt to the `qwen3-coder-plus` model. Responses appear in the Qwen Code output channel.
+
 # Requirements
 
 To use this extension, you'll need:

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qwen-code-vscode-ide-companion",
   "displayName": "Qwen Code Companion",
-  "description": "Enable Qwen Code with direct access to your VS Code workspace.",
+  "description": "Use Qwen 3 Coder Plus inside VS Code.",
   "version": "0.0.4",
   "publisher": "qwenlm",
   "icon": "assets/icon.png",
@@ -28,7 +28,7 @@
     "ide companion"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "onCommand:qwen-code.runQwenCode"
   ],
   "contributes": {
     "commands": [


### PR DESCRIPTION
## Summary
- query qwen3-coder-plus from a new VS Code command
- document QWEN_API_KEY usage and command activation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689660262b84832d91dca934dda2bdce

## Summary by Sourcery

Enable direct integration of the qwen3-coder-plus model in VS Code by adding a new command, updating extension metadata, and documenting API key usage

New Features:
- Add a VS Code command to query the qwen3-coder-plus model and display responses in the Qwen Code output channel

Enhancements:
- Rename output channel and extension metadata from Gemini CLI to Qwen Code
- Change activation event to trigger on the qwen-code.runQwenCode command

Documentation:
- Document QWEN_API_KEY environment variable setup and how to run the Qwen Code command in README